### PR TITLE
Do 167 unit test linter warnings

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -51,7 +51,7 @@ module.exports = function (config) {
     },
     port: 9876,
     colors: true,
-    logLevel: config.LOG_INFO,
+    logLevel: config.LOG_ERROR,
     autoWatch: true,
     browsers: browser,
     singleRun: false

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "e2e-report-open": "open ./e2e/reports/html/feature_test_report.html",
     "hmr": "ng serve --open --hmr -e=hmr --proxy-config config/proxy.conf.json",
     "json-server": "nodemon --watch ./json-server/ ./json-server/server.js --delay 2",
-    "lint": "ng lint",
+    "lint": "ng lint --type-check",
     "ng": "ng",
     "start": "ng serve --proxy-config config/proxy.conf.json",
     "test": "ng test --watch=false",


### PR DESCRIPTION
Avoid linter warning by adding --type-check flag to ng lint

Suppress karma 404 warnings
- Had hoped to stop warnings at the source by correcting the root cause, but was unsuccessful after trying various approaches.  
- Reconfigured Karma to log errors only, so warnings are suppressed.