### PR TITLE
Graigjanssen/do 138 increase feature test coverage

### DIFF
--- a/e2e/feature/authentication/login/login.feature
+++ b/e2e/feature/authentication/login/login.feature
@@ -8,7 +8,7 @@ Scenario: The user with valid credentials can log in
   When the user logs in with valid credentials
   Then the user should see their personalized dashboard
 
-Scenario Outline: The user is alerted if fields are left blank
+Scenario Outline: The user is alerted if the <field> field is left blank
   Given the user navigates to the CapDash2 homepage
   And the user is logged out
   When the user clicks the <field> input field and enters no text

--- a/e2e/feature/authentication/login/login.feature
+++ b/e2e/feature/authentication/login/login.feature
@@ -7,3 +7,14 @@ Scenario: The user with valid credentials can log in
   Given the user navigates to the CapDash2 homepage
   When the user logs in with valid credentials
   Then the user should see their personalized dashboard
+
+Scenario Outline: The user is alerted if fields are left blank
+  Given the user navigates to the CapDash2 homepage
+  When the user enters text in the <field> field
+  And the user removes all text in the <field> field
+  Then an alert message reading <text> is displayed
+
+  Examples:
+    | field    | text                       |
+    | email    | "You must add an email."   |
+    | password | "You must add a password." |

--- a/e2e/feature/authentication/login/login.feature
+++ b/e2e/feature/authentication/login/login.feature
@@ -10,11 +10,13 @@ Scenario: The user with valid credentials can log in
 
 Scenario Outline: The user is alerted if fields are left blank
   Given the user navigates to the CapDash2 homepage
-  When the user enters text in the <field> field
-  And the user removes all text in the <field> field
+  And the user is logged out
+  When the user clicks the <field> input field and enters no text
+  And the user clicks outside of the input field
   Then an alert message reading <text> is displayed
+  And the sign in button should be disabled
 
   Examples:
-    | field    | text                       |
-    | email    | "You must add an email."   |
-    | password | "You must add a password." |
+    | field    | text                     |
+    | email    | You must add an email.   |
+    | password | You must add a password. |

--- a/e2e/feature/authentication/login/step_definitions/loginFeature_steps.ts
+++ b/e2e/feature/authentication/login/step_definitions/loginFeature_steps.ts
@@ -1,4 +1,4 @@
-import { browser} from 'protractor';
+import { browser, element, by } from 'protractor';
 import { LoginPage } from '../../../../page-objects/login.po';
 import { Capdash2Page } from '../../../../page-objects/app.po';
 
@@ -22,6 +22,20 @@ defineSupportCode(({Given, When, Then}) => {
       browser.getCurrentUrl().then(url => {
         expect(/login/.test(url)).not.to.equal(true);
       });
+    });
+  });
+
+  When('the user clicks the {field} input field and enters no text', (field) => {
+    return page.getField(field).click();
+  });
+
+  When('the user clicks outside of the input field', () => {
+    return page.loginHeader.click();
+  });
+
+  Then('an alert message reading {text} is displayed', (text) => {
+    return page.getAlert(text).isDisplayed().then( isDisplayed => {
+      expect(isDisplayed).to.equal(true);
     });
   });
 

--- a/e2e/feature/authentication/login/step_definitions/loginFeature_steps.ts
+++ b/e2e/feature/authentication/login/step_definitions/loginFeature_steps.ts
@@ -39,6 +39,14 @@ defineSupportCode(({Given, When, Then}) => {
     });
   });
 
+  Then('the sign in button should be disabled', () => {
+    return page.loginBtn.click().then(() => {
+      browser.getCurrentUrl().then( url => {
+        expect(/login/.test(url)).to.equal(true);
+      });
+    });
+  });
+
   Then('the user should see their personalized dashboard', () => {
     return app.getAppHeader().then( header => {
       header.isDisplayed().then(isDisplayed => {

--- a/e2e/feature/authentication/logout/logout.feature
+++ b/e2e/feature/authentication/logout/logout.feature
@@ -5,7 +5,7 @@ Feature: CapDash2 User Logout
 
 Scenario: A user that is logged in can log out
   Given the user is logged in
-  When the user selects the user menu
+  When the user selects the User menu
   Then the user should see the option to log out
   When the user selects log out
   Then the user should navigate to the login page

--- a/e2e/feature/authentication/logout/step_definitions/logoutFeature_steps.ts
+++ b/e2e/feature/authentication/logout/step_definitions/logoutFeature_steps.ts
@@ -18,6 +18,14 @@ defineSupportCode(({Given, Then, When}) => {
     });
   });
 
+  Given('the user is logged out', () => {
+    helpers.logout();
+
+    return browser.getCurrentUrl().then(url => {
+      expect(/login/.test(url)).to.equal(true);
+    });
+  })
+
   Then('the user should see the option to log out', () => {
     return header.getElement('user', 'child').isDisplayed().then(displayed => {
       expect(displayed).to.equal(true);

--- a/e2e/feature/authentication/logout/step_definitions/logoutFeature_steps.ts
+++ b/e2e/feature/authentication/logout/step_definitions/logoutFeature_steps.ts
@@ -1,6 +1,6 @@
 import { browser, element, by } from 'protractor';
 import { HeaderPage } from '../../../../page-objects/header.po';
-import { E2EHelpers } from '../../../../support/e2eHelpers';
+import { LoginPage } from '../../../../page-objects/login.po';
 
 import { defineSupportCode } from 'cucumber';
 
@@ -8,10 +8,10 @@ import { expect } from 'chai';
 
 defineSupportCode(({Given, Then, When}) => {
   const header: HeaderPage = new HeaderPage();
-  const helpers: E2EHelpers = new E2EHelpers();
+  const loginPage: LoginPage = new LoginPage();
 
   Given('the user is logged in', () => {
-    helpers.confirmLogin();
+    loginPage.confirmLogin();
 
     return browser.getCurrentUrl().then(url => {
       expect(/login/.test(url)).not.to.equal(true);
@@ -19,7 +19,7 @@ defineSupportCode(({Given, Then, When}) => {
   });
 
   Given('the user is logged out', () => {
-    helpers.logout();
+    header.logout();
 
     return browser.getCurrentUrl().then(url => {
       expect(/login/.test(url)).to.equal(true);
@@ -27,13 +27,13 @@ defineSupportCode(({Given, Then, When}) => {
   })
 
   Then('the user should see the option to log out', () => {
-    return header.getElement('user', 'child').isDisplayed().then(displayed => {
+    return header.getItem('Logout').element.isDisplayed().then(displayed => {
       expect(displayed).to.equal(true);
     });
   });
 
   When('the user selects log out', () => {
-    return header.getElement('user', 'child').click();
+    return header.getItem('Logout').element.click();
   });
 
   Then('the user should navigate to the login page', () => {

--- a/e2e/feature/dashboard/header/header.feature
+++ b/e2e/feature/dashboard/header/header.feature
@@ -5,9 +5,9 @@ Feature: Capacity Dashboard Header
 
 Background:
   Given the user is logged in
+  And the Capacity Dashboard header is loaded
 
 Scenario Outline: The user can access the <menu> header menu
-  Given the Capacity Dashboard header is loaded
   When the user selects the <menu> menu
   Then the user should see the <menu> menu
   When the user selects the <menu> menu
@@ -21,7 +21,6 @@ Scenario Outline: The user can access the <menu> header menu
     | user          |
 
 Scenario: The user can switch between header menus
-  Given the Capacity Dashboard header is loaded
   When the user selects the mega-menu menu
   Then the user should see the mega-menu menu
   When the user selects the user menu

--- a/e2e/feature/dashboard/header/header.feature
+++ b/e2e/feature/dashboard/header/header.feature
@@ -15,14 +15,14 @@ Scenario Outline: The user can access the <menu> header menu
 
   Examples:
     | menu          |
-    | mega-menu     |
-    | notifications |
-    | languages     |
-    | user          |
+    | Mega-menu     |
+    | Notifications |
+    | Languages     |
+    | User          |
 
 Scenario: The user can switch between header menus
-  When the user selects the mega-menu menu
-  Then the user should see the mega-menu menu
-  When the user selects the user menu
-  Then the user should see the user menu
-  And the user should not see the mega-menu menu
+  When the user selects the Mega-menu menu
+  Then the user should see the Mega-menu menu
+  When the user selects the User menu
+  Then the user should see the User menu
+  And the user should not see the Mega-menu menu

--- a/e2e/feature/dashboard/header/header.feature
+++ b/e2e/feature/dashboard/header/header.feature
@@ -9,9 +9,9 @@ Background:
 
 Scenario Outline: The user can access the <menu> header menu
   When the user selects the <menu> menu
-  Then the user should see the <menu> menu
+  Then the <menu> menu should be displayed
   When the user selects the <menu> menu
-  Then the user should not see the <menu> menu
+  Then the <menu> menu should be hidden
 
   Examples:
     | menu          |
@@ -33,7 +33,7 @@ Scenario Outline: The user can navigate to the <page> page through the <menu> he
 
 Scenario: The user can switch between header menus
   When the user selects the Mega-menu menu
-  Then the user should see the Mega-menu menu
+  Then the Mega-menu menu should be displayed
   When the user selects the User menu
-  Then the user should see the User menu
-  And the user should not see the Mega-menu menu
+  Then the User menu should be displayed
+  And the Mega-menu menu should be hidden

--- a/e2e/feature/dashboard/header/header.feature
+++ b/e2e/feature/dashboard/header/header.feature
@@ -20,6 +20,17 @@ Scenario Outline: The user can access the <menu> header menu
     | Languages     |
     | User          |
 
+Scenario Outline: The user can navigate to the <page> page through the <menu> header menu
+  When the user selects the <menu> menu
+  And the user selects the <link> link
+  Then the user should navigate to the <link> page from the header
+
+  Examples:
+    | menu | link                 |
+    | User | Edit Profile         |
+    | User | Work Orders Schedule |
+    | User | CapApp Setting       |
+
 Scenario: The user can switch between header menus
   When the user selects the Mega-menu menu
   Then the user should see the Mega-menu menu

--- a/e2e/feature/dashboard/header/header.feature
+++ b/e2e/feature/dashboard/header/header.feature
@@ -6,7 +6,7 @@ Feature: Capacity Dashboard Header
 Background:
   Given the user is logged in
 
-Scenario Outline: The user can access header menus
+Scenario Outline: The user can access the <menu> header menu
   Given the Capacity Dashboard header is loaded
   When the user selects the <menu> menu
   Then the user should see the <menu> menu
@@ -14,11 +14,11 @@ Scenario Outline: The user can access header menus
   Then the user should not see the <menu> menu
 
   Examples:
-    | menu |
-    | mega-menu |
+    | menu          |
+    | mega-menu     |
     | notifications |
-    | languages |
-    | user |
+    | languages     |
+    | user          |
 
 Scenario: The user can switch between header menus
   Given the Capacity Dashboard header is loaded

--- a/e2e/feature/dashboard/header/step_definitions/headerFeature_steps.ts
+++ b/e2e/feature/dashboard/header/step_definitions/headerFeature_steps.ts
@@ -22,6 +22,10 @@ defineSupportCode(({Given, When, Then}) => {
     return header.getItem(menu).element.click();
   });
 
+  When('the user selects the {link} link', (link) => {
+    return header.getItem(link).element.click();
+  });
+
   Then('the user should see the {menu} menu', (menu) => {
     return header.getChild(menu).element.isPresent().then(present => {
       expect(present).to.equal(true);
@@ -33,5 +37,13 @@ defineSupportCode(({Given, When, Then}) => {
       expect(present).to.equal(false);
     });
   });
+
+  Then('the user should navigate to the {link} page from the header', (link) => {
+    const expectedUrl = new RegExp(header.getItem(link).path);
+
+    return browser.getCurrentUrl().then( url => {
+      expect(expectedUrl.test(url)).to.equal(true);
+    });
+  })
 
 });

--- a/e2e/feature/dashboard/header/step_definitions/headerFeature_steps.ts
+++ b/e2e/feature/dashboard/header/step_definitions/headerFeature_steps.ts
@@ -19,17 +19,17 @@ defineSupportCode(({Given, When, Then}) => {
   });
 
   When('the user selects the {menu} menu', (menu) => {
-    return header.getElement(menu, 'parent').click();
+    return header.getItem(menu).element.click();
   });
 
   Then('the user should see the {menu} menu', (menu) => {
-    return header.getElement(menu, 'child').isPresent().then(present => {
+    return header.getChild(menu).element.isPresent().then(present => {
       expect(present).to.equal(true);
     });
   });
 
   Then('the user should not see the {menu} menu', (menu) => {
-    return header.getElement(menu, 'child').isPresent().then(present => {
+    return header.getChild(menu).element.isPresent().then(present => {
       expect(present).to.equal(false);
     });
   });

--- a/e2e/feature/dashboard/header/step_definitions/headerFeature_steps.ts
+++ b/e2e/feature/dashboard/header/step_definitions/headerFeature_steps.ts
@@ -26,15 +26,11 @@ defineSupportCode(({Given, When, Then}) => {
     return header.getItem(link).element.click();
   });
 
-  Then('the user should see the {menu} menu', (menu) => {
-    return header.getChild(menu).element.isPresent().then(present => {
-      expect(present).to.equal(true);
-    });
-  });
+  Then('the {menu} menu should be {visibility}', (menu, visibility) => {
+    const expected = visibility === 'displayed' ? true : false;
 
-  Then('the user should not see the {menu} menu', (menu) => {
-    return header.getChild(menu).element.isPresent().then(present => {
-      expect(present).to.equal(false);
+    return header.getChild(menu).element.isPresent().then( isPresent => {
+      expect(isPresent).to.equal(expected);
     });
   });
 
@@ -44,6 +40,6 @@ defineSupportCode(({Given, When, Then}) => {
     return browser.getCurrentUrl().then( url => {
       expect(expectedUrl.test(url)).to.equal(true);
     });
-  })
+  });
 
 });

--- a/e2e/feature/dashboard/sidebar/sidebar.feature
+++ b/e2e/feature/dashboard/sidebar/sidebar.feature
@@ -9,7 +9,7 @@ Background:
 
 Scenario Outline: The user can navigate using the <item> top level link
   When the user selects the <item> sidebar item
-  Then the user should see the <item> page
+  Then the user should navigate to the <item> page from the sidebar
   And the <item> sidebar item should be highlighted
 
   Examples:
@@ -21,7 +21,7 @@ Scenario Outline: The user can navigate using links in the <item> sub menu
   When the user selects the <item> sidebar item
   Then the user should see the <sub-item> item in the <item> sub-menu
   When the user selects the <sub-item> sub-menu item from the <item> sub-menu
-  Then the user should see the <sub-item> page
+  Then the user should navigate to the <sub-item> page from the sidebar
   And the <item> sidebar item should be highlighted
   And the <sub-item> sidebar item should be highlighted
 
@@ -42,7 +42,7 @@ Scenario: The user can navigate to individual reports using Other Reports
   When the user selects the Other Reports sub-menu item from the Reports sub-menu
   Then the user should see the Report All item in the Other Reports sub-menu
   When the user selects the Report All sub-menu item from the Other Reports sub-menu
-  Then the user should see the Report All page
+  Then the user should navigate to the Report All page from the sidebar
   And the Reports sidebar item should be highlighted
   And the Report All sidebar item should be highlighted
 

--- a/e2e/feature/dashboard/sidebar/sidebar.feature
+++ b/e2e/feature/dashboard/sidebar/sidebar.feature
@@ -7,7 +7,7 @@ Background:
   Given the user is logged in
   And the Capacity Dashboard sidebar is loaded
 
-Scenario Outline: The user can navigate with top level links
+Scenario Outline: The user can navigate using the <item> top level link
   When the user selects the <item> sidebar item
   Then the user should see the <item> page
   And the <item> sidebar item should be highlighted
@@ -17,7 +17,7 @@ Scenario Outline: The user can navigate with top level links
     | Edit Demand & Projections |
     | Intake/Vacancy Control    |
 
-Scenario Outline: The user can navigate using links in sub menus
+Scenario Outline: The user can navigate using links in the <item> sub menu
   When the user selects the <item> sidebar item
   Then the user should see the <sub-item> item in the <item> sub-menu
   When the user selects the <sub-item> sub-menu item from the <item> sub-menu

--- a/e2e/feature/dashboard/sidebar/sidebar.feature
+++ b/e2e/feature/dashboard/sidebar/sidebar.feature
@@ -27,7 +27,7 @@ Scenario Outline: The user can navigate using links in the <item> sub menu
 
   Examples:
     | item         | sub-item             |
-    | Dashboard    | Dashboard            |
+    | Dashboard    | Main Dashboard       |
     | Units        | Offline Units        |
     | Units        | HERO                 |
     | Units        | L.T.R.               |

--- a/e2e/feature/dashboard/sidebar/sidebar.feature
+++ b/e2e/feature/dashboard/sidebar/sidebar.feature
@@ -36,6 +36,16 @@ Scenario Outline: The user can navigate using links in the <item> sub menu
     | App Settings | General Settings     |
     | App Help     | General Help         |
 
+Scenario: The user can navigate to individual reports using Other Reports
+  When the user selects the Reports sidebar item
+  Then the user should see the Other Reports item in the Reports sub-menu
+  When the user selects the Other Reports sub-menu item from the Reports sub-menu
+  Then the user should see the Report All item in the Other Reports sub-menu
+  When the user selects the Report All sub-menu item from the Other Reports sub-menu
+  Then the user should see the Report All page
+  And the Reports sidebar item should be highlighted
+  And the Report All sidebar item should be highlighted
+
 Scenario: Sub menu collapses when another is expanded
   When the user selects the Units sidebar item
   Then the user should see the Offline Units item in the Units sub-menu

--- a/e2e/feature/dashboard/sidebar/step_definitions/sidebarFeature_steps.ts
+++ b/e2e/feature/dashboard/sidebar/step_definitions/sidebarFeature_steps.ts
@@ -26,7 +26,7 @@ defineSupportCode(({Given, When, Then}) => {
 
   When('the user selects the {sub-item} sub-menu item from the {item} sub-menu',
   (subItem, item) => {
-    return sidebar.getSubItem(subItem, item).element.click();
+    return sidebar.getItem(subItem).element.click();
   });
 
   When(/the user selects the sidebar minify button/, () => {
@@ -46,7 +46,7 @@ defineSupportCode(({Given, When, Then}) => {
   });
 
   Then('the user should see the {sub-item} item in the {item} sub-menu', (subItem, item) => {
-    return sidebar.getSubItem(subItem, item).element.isDisplayed().then( isDisplayed => {
+    return sidebar.getItem(subItem).element.isDisplayed().then( isDisplayed => {
       expect(isDisplayed).to.equal(true);
     });
   });
@@ -58,7 +58,7 @@ defineSupportCode(({Given, When, Then}) => {
   });
 
   Then('the Offline Units item in the Units sub-menu should not be visible', () => {
-    const offlineUnits =  sidebar.getSubItem('Offline Units', 'Units');
+    const offlineUnits =  sidebar.getItem('Offline Units');
 
     return offlineUnits.element.isDisplayed().then( isDisplayed => {
       expect(isDisplayed).to.equal(false);

--- a/e2e/feature/dashboard/sidebar/step_definitions/sidebarFeature_steps.ts
+++ b/e2e/feature/dashboard/sidebar/step_definitions/sidebarFeature_steps.ts
@@ -65,7 +65,7 @@ defineSupportCode(({Given, When, Then}) => {
     });
   });
 
-  Then('the user should see the {item} page', (item) => {
+  Then('the user should navigate to the {item} page from the sidebar', (item) => {
     const expectedUrl = new RegExp(sidebar.getItem(item).path);
 
     return browser.getCurrentUrl().then( url => {

--- a/e2e/page-objects/header.po.ts
+++ b/e2e/page-objects/header.po.ts
@@ -32,6 +32,18 @@ export class HeaderPage {
     'User': {
       element: element(by.css('.navbar-user')),
       children: {
+        'Edit Profile': {
+          element: element(by.cssContainingText('li > a', 'Edit Profile')),
+          path: '#/app/extra/profile'
+        },
+        'Work Orders Schedule': {
+          element: element(by.cssContainingText('li > a', 'Work Orders Schedule')),
+          path: '#/app/work_orders/work_orders/calendar'
+        },
+        'CapApp Setting': {
+          element: element(by.cssContainingText('li > a', 'CapApp Setting')),
+          path: '#/app/settings/settings/app_settings'
+        },
         'Logout': {
           element: element(by.css('.logout'))
         }

--- a/e2e/page-objects/header.po.ts
+++ b/e2e/page-objects/header.po.ts
@@ -1,40 +1,39 @@
 import { browser, element, by } from 'protractor';
+import { E2EHelpers } from '../support/e2eHelpers';
+
+const helpers = new E2EHelpers();
 
 export class HeaderPage {
-  megaMenu = {
-    parent: element(by.css('.dropdown-lg')),
-    child: element(by.css('.dropdown-header'))
-  }
-
-  notificationsMenu = {
-    parent: element(by.css('.bell')),
-    child: element(by.css('.media-list'))
-  }
-
-  languagesMenu = {
-    parent: element(by.css('.navbar-language')),
-    child: element(by.css('.languages-menu'))
-  }
-
-  userMenu = {
-    parent: element(by.css('.navbar-user')),
-    child: element(by.css('.logout'))
-  }
-
-  getElement (name, elementType) {
-
-    switch (name) {
-      case 'mega-menu':
-        return this.megaMenu[elementType];
-      case 'notifications':
-        return this.notificationsMenu[elementType];
-      case 'languages':
-        return this.languagesMenu[elementType];
-      case 'user':
-        return this.userMenu[elementType];
+  items = {
+    'Mega-menu': {
+      element: element(by.css('.dropdown-lg')),
+      'Mega-menu Header': {
+        element: element(by.css('.dropdown-header'))
+      }
+    },
+    'Notifications': {
+      element: element(by.css('.bell')),
+      'Media List': {
+        element: element(by.css('.media-list'))
+      }
+    },
+    'Languages': {
+      element: element(by.css('.navbar-language')),
+      'Languages List': {
+        element: element(by.css('.languages-menu'))
+      }
+    },
+    'User': {
+      element: element(by.css('.navbar-user')),
+      'Logout': {
+        element: element(by.css('.logout'))
+      }
     }
   }
 
+  getItem(item) {
+    return helpers.getItem(item, this.items);
+  }
   navigateTo () {
     return browser.get('/');
   }

--- a/e2e/page-objects/header.po.ts
+++ b/e2e/page-objects/header.po.ts
@@ -9,7 +9,7 @@ export class HeaderPage {
       element: element(by.css('.dropdown-lg')),
       children: {
         'Mega-menu Header': {
-          element: element(by.css('.dropdown-header'))
+          element: element(by.cssContainingText('h4', 'Apps'))
         }
       }
     },

--- a/e2e/page-objects/header.po.ts
+++ b/e2e/page-objects/header.po.ts
@@ -7,26 +7,34 @@ export class HeaderPage {
   items = {
     'Mega-menu': {
       element: element(by.css('.dropdown-lg')),
-      'Mega-menu Header': {
-        element: element(by.css('.dropdown-header'))
+      children: {
+        'Mega-menu Header': {
+          element: element(by.css('.dropdown-header'))
+        }
       }
     },
     'Notifications': {
       element: element(by.css('.bell')),
-      'Media List': {
-        element: element(by.css('.media-list'))
+      children: {
+        'Media List': {
+          element: element(by.css('.media-list'))
+        }
       }
     },
     'Languages': {
       element: element(by.css('.navbar-language')),
-      'Languages List': {
-        element: element(by.css('.languages-menu'))
+      children: {
+        'Languages List': {
+          element: element(by.css('.languages-menu'))
+        }
       }
     },
     'User': {
       element: element(by.css('.navbar-user')),
-      'Logout': {
-        element: element(by.css('.logout'))
+      children: {
+        'Logout': {
+          element: element(by.css('.logout'))
+        }
       }
     }
   }
@@ -34,8 +42,23 @@ export class HeaderPage {
   getItem(item) {
     return helpers.getItem(item, this.items);
   }
+
+  getChild(item) {
+    return helpers.getChild(item, this.items);
+  }
+
   navigateTo () {
     return browser.get('/');
+  }
+
+  logout() {
+    return browser.getCurrentUrl().then( url => {
+      if (!/login/.test(url)) {
+        return this.getItem('User').element.click().then(() => {
+          return this.getItem('Logout').element.click();
+        });
+      }
+    });
   }
 
 }

--- a/e2e/page-objects/login.po.ts
+++ b/e2e/page-objects/login.po.ts
@@ -47,4 +47,13 @@ export class LoginPage {
   getAlert(text) {
     return element(by.cssContainingText('.alert-danger', text));
   }
+
+  confirmLogin () {
+    return browser.getCurrentUrl().then(url => {
+      if (/login/.test(url)) {
+        this.login('sample_user@hra.nyc.gov', 'password');
+      }
+    });
+  }
+
 }

--- a/e2e/page-objects/login.po.ts
+++ b/e2e/page-objects/login.po.ts
@@ -3,6 +3,7 @@ import { browser, element, by } from 'protractor';
 export class LoginPage {
   emailField = element(by.css('input[type=email]'));
   passwordField = element(by.css('input[type=password]'));
+  loginBtn = element(by.buttonText('Sign me in'));
   loginHeader = element(by.css('.login-header'));
 
   navigateTo() {
@@ -26,9 +27,7 @@ export class LoginPage {
   }
 
   signIn() {
-    const btn = element(by.buttonText('Sign me in'));
-
-    return btn.click();
+    return this.loginBtn.click();
   }
 
   login(email, password) {

--- a/e2e/page-objects/login.po.ts
+++ b/e2e/page-objects/login.po.ts
@@ -26,15 +26,11 @@ export class LoginPage {
     this.passwordField.sendKeys(password);
   }
 
-  signIn() {
-    return this.loginBtn.click();
-  }
-
   login(email, password) {
     this.enterEmail(email);
     this.enterPassword(password);
 
-    return this.signIn();
+    return this.loginBtn.click();
   }
 
   getField(field) {

--- a/e2e/page-objects/login.po.ts
+++ b/e2e/page-objects/login.po.ts
@@ -1,6 +1,9 @@
 import { browser, element, by } from 'protractor';
 
 export class LoginPage {
+  emailField = element(by.css('input[type=email]'));
+  passwordField = element(by.css('input[type=password]'));
+  loginHeader = element(by.css('.login-header'));
 
   navigateTo() {
     return browser.get('/');
@@ -15,15 +18,11 @@ export class LoginPage {
   }
 
   enterEmail(email) {
-    const emailField = element(by.css('input[type=email]'));
-
-    emailField.sendKeys(email);
+    this.emailField.sendKeys(email);
   }
 
   enterPassword(password) {
-    const passwordField = element(by.css('input[type=password]'));
-
-    passwordField.sendKeys(password);
+    this.passwordField.sendKeys(password);
   }
 
   signIn() {
@@ -37,5 +36,16 @@ export class LoginPage {
     this.enterPassword(password);
 
     return this.signIn();
+  }
+
+  getField(field) {
+    switch (field) {
+      case 'email': return this.emailField;
+      case 'password': return this.passwordField;
+    }
+  }
+
+  getAlert(text) {
+    return element(by.cssContainingText('.alert-danger', text));
   }
 }

--- a/e2e/page-objects/sidebar.po.ts
+++ b/e2e/page-objects/sidebar.po.ts
@@ -8,7 +8,7 @@ export class SidebarPage {
     'Dashboard': {
       element: element(by.css('#sidebar-dashboard')),
       subItems: {
-        'Dashboard': {
+        'Main Dashboard': {
           element: element(by.css('#sidebar-sub-dashboard')),
           path: 'dashboard'
         }

--- a/e2e/page-objects/sidebar.po.ts
+++ b/e2e/page-objects/sidebar.po.ts
@@ -46,6 +46,15 @@ export class SidebarPage {
         'General Reports': {
           element: element(by.css('#sidebar-reports-general')),
           path: 'reports/general'
+        },
+        'Other Reports': {
+          element: element(by.css('#sidebar-reports-other')),
+          subItems: {
+            'Report All': {
+              element: element(by.css('#sidebar-reports-other-all')),
+              path: 'reports/all'
+            }
+          }
         }
       }
     },
@@ -75,18 +84,31 @@ export class SidebarPage {
   getItem(item) {
     const items = this.items;
 
-    if (item in items) {
-      return items[item];
-    } else {
-      for (const menuItem in items) {
-        if (items[menuItem].subItems && items[menuItem].subItems[item]) {
-          return items[menuItem].subItems[item];
+    return item in items ? items[item] : this.findItem(item, items);
+  }
+
+  findItem(item, itemsObj) {
+    for (const menuItem in itemsObj) {
+      if (itemsObj[menuItem].subItems) {
+        if (itemsObj[menuItem].subItems[item]) {
+          return itemsObj[menuItem].subItems[item];
+        } else {
+          const found = this.findItem(item, itemsObj[menuItem].subItems);
+          if (found) {
+            return found;
+          }
         }
       }
     }
   }
 
   getSubItem(subItem, item) {
-    return this.items[item].subItems[subItem];
+    const items = this.items;
+
+    if (item in items) {
+      return items[item].subItems[subItem];
+    } else {
+      return this.getItem(item).subItems[subItem];
+    }
   }
 }

--- a/e2e/page-objects/sidebar.po.ts
+++ b/e2e/page-objects/sidebar.po.ts
@@ -7,28 +7,32 @@ export class SidebarPage {
   items = {
     'Dashboard': {
       element: element(by.css('#sidebar-dashboard')),
-      'Main Dashboard': {
-        element: element(by.css('#sidebar-sub-dashboard')),
-        path: 'dashboard'
+      children: {
+        'Main Dashboard': {
+          element: element(by.css('#sidebar-sub-dashboard')),
+          path: 'dashboard'
+        }
       }
     },
     'Units': {
       element: element(by.css('#sidebar-units')),
-      'Offline Units': {
-        element: element(by.css('#sidebar-units-offline')),
-        path: 'units/offline-units'
-      },
-      'HERO': {
-        element: element(by.css('#sidebar-units-hero')),
-        path: 'units/hero'
-      },
-      'L.T.R.': {
-        element: element(by.css('#sidebar-units-ltr')),
-        path: 'units/ltr'
-      },
-      'Demand & Projections': {
-        element: element(by.css('#sidebar-units-demand')),
-        path: 'units/demand'
+      children: {
+        'Offline Units': {
+          element: element(by.css('#sidebar-units-offline')),
+          path: 'units/offline-units'
+        },
+        'HERO': {
+          element: element(by.css('#sidebar-units-hero')),
+          path: 'units/hero'
+        },
+        'L.T.R.': {
+          element: element(by.css('#sidebar-units-ltr')),
+          path: 'units/ltr'
+        },
+        'Demand & Projections': {
+          element: element(by.css('#sidebar-units-demand')),
+          path: 'units/demand'
+        }
       }
     },
     'Edit Demand & Projections': {
@@ -41,30 +45,38 @@ export class SidebarPage {
     },
     'Reports': {
       element: element(by.css('#sidebar-reports')),
-      'General Reports': {
-        element: element(by.css('#sidebar-reports-general')),
-        path: 'reports/general'
-      },
-      'Other Reports': {
-        element: element(by.css('#sidebar-reports-other')),
-        'Report All': {
-          element: element(by.css('#sidebar-reports-other-all')),
-          path: 'reports/all'
+      children: {
+        'General Reports': {
+          element: element(by.css('#sidebar-reports-general')),
+          path: 'reports/general'
+        },
+        'Other Reports': {
+          element: element(by.css('#sidebar-reports-other')),
+          children: {
+            'Report All': {
+              element: element(by.css('#sidebar-reports-other-all')),
+              path: 'reports/all'
+            }
+          }
         }
       }
     },
     'App Settings': {
       element: element(by.css('#sidebar-settings')),
-      'General Settings': {
-        element: element(by.css('#sidebar-settings-general')),
-        path: 'settings/general'
+      children: {
+        'General Settings': {
+          element: element(by.css('#sidebar-settings-general')),
+          path: 'settings/general'
+        }
       }
     },
     'App Help': {
       element: element(by.css('#sidebar-help')),
-      'General Help': {
-        element: element(by.css('#sidebar-help-general')),
-        path: 'help/general'
+      children: {
+        'General Help': {
+          element: element(by.css('#sidebar-help-general')),
+          path: 'help/general'
+        }
       }
     }
   }

--- a/e2e/page-objects/sidebar.po.ts
+++ b/e2e/page-objects/sidebar.po.ts
@@ -7,32 +7,28 @@ export class SidebarPage {
   items = {
     'Dashboard': {
       element: element(by.css('#sidebar-dashboard')),
-      subItems: {
-        'Main Dashboard': {
-          element: element(by.css('#sidebar-sub-dashboard')),
-          path: 'dashboard'
-        }
+      'Main Dashboard': {
+        element: element(by.css('#sidebar-sub-dashboard')),
+        path: 'dashboard'
       }
     },
     'Units': {
       element: element(by.css('#sidebar-units')),
-      subItems: {
-        'Offline Units': {
-          element: element(by.css('#sidebar-units-offline')),
-          path: 'units/offline-units'
-        },
-        'HERO': {
-          element: element(by.css('#sidebar-units-hero')),
-          path: 'units/hero'
-        },
-        'L.T.R.': {
-          element: element(by.css('#sidebar-units-ltr')),
-          path: 'units/ltr'
-        },
-        'Demand & Projections': {
-          element: element(by.css('#sidebar-units-demand')),
-          path: 'units/demand'
-        }
+      'Offline Units': {
+        element: element(by.css('#sidebar-units-offline')),
+        path: 'units/offline-units'
+      },
+      'HERO': {
+        element: element(by.css('#sidebar-units-hero')),
+        path: 'units/hero'
+      },
+      'L.T.R.': {
+        element: element(by.css('#sidebar-units-ltr')),
+        path: 'units/ltr'
+      },
+      'Demand & Projections': {
+        element: element(by.css('#sidebar-units-demand')),
+        path: 'units/demand'
       }
     },
     'Edit Demand & Projections': {
@@ -45,38 +41,30 @@ export class SidebarPage {
     },
     'Reports': {
       element: element(by.css('#sidebar-reports')),
-      subItems: {
-        'General Reports': {
-          element: element(by.css('#sidebar-reports-general')),
-          path: 'reports/general'
-        },
-        'Other Reports': {
-          element: element(by.css('#sidebar-reports-other')),
-          subItems: {
-            'Report All': {
-              element: element(by.css('#sidebar-reports-other-all')),
-              path: 'reports/all'
-            }
-          }
+      'General Reports': {
+        element: element(by.css('#sidebar-reports-general')),
+        path: 'reports/general'
+      },
+      'Other Reports': {
+        element: element(by.css('#sidebar-reports-other')),
+        'Report All': {
+          element: element(by.css('#sidebar-reports-other-all')),
+          path: 'reports/all'
         }
       }
     },
     'App Settings': {
       element: element(by.css('#sidebar-settings')),
-      subItems: {
-        'General Settings': {
-          element: element(by.css('#sidebar-settings-general')),
-          path: 'settings/general'
-        }
+      'General Settings': {
+        element: element(by.css('#sidebar-settings-general')),
+        path: 'settings/general'
       }
     },
     'App Help': {
       element: element(by.css('#sidebar-help')),
-      subItems: {
-        'General Help': {
-          element: element(by.css('#sidebar-help-general')),
-          path: 'help/general'
-        }
+      'General Help': {
+        element: element(by.css('#sidebar-help-general')),
+        path: 'help/general'
       }
     }
   }
@@ -86,9 +74,5 @@ export class SidebarPage {
 
   getItem(item) {
     return helpers.getItem(item, this.items);
-  }
-
-  getSubItem(subItem, item) {
-    return helpers.getSubItem(subItem, item, this.items);
   }
 }

--- a/e2e/page-objects/sidebar.po.ts
+++ b/e2e/page-objects/sidebar.po.ts
@@ -6,7 +6,7 @@ const helpers = new E2EHelpers();
 export class SidebarPage {
   items = {
     'Dashboard': {
-      element: element(by.css('#sidebar-dashboard')),
+      element: element(by.cssContainingText('li.has-sub', 'Dashboard')),
       children: {
         'Main Dashboard': {
           element: element(by.css('#sidebar-sub-dashboard')),

--- a/e2e/page-objects/sidebar.po.ts
+++ b/e2e/page-objects/sidebar.po.ts
@@ -9,52 +9,52 @@ export class SidebarPage {
       element: element(by.cssContainingText('li.has-sub', 'Dashboard')),
       children: {
         'Main Dashboard': {
-          element: element(by.css('#sidebar-sub-dashboard')),
+          element: element(by.xpath('//ul[@class="sub-menu"]/li/a[text()[contains(., "Dashboard")]]/..')),
           path: 'dashboard'
         }
       }
     },
     'Units': {
-      element: element(by.css('#sidebar-units')),
+      element: element(by.cssContainingText('li.has-sub', 'Units')),
       children: {
         'Offline Units': {
-          element: element(by.css('#sidebar-units-offline')),
+          element: element(by.xpath('//a[text()[contains(., "Offline Units")]]/..')),
           path: 'units/offline-units'
         },
         'HERO': {
-          element: element(by.css('#sidebar-units-hero')),
+          element: element(by.xpath('//a[text()[contains(., "HERO")]]/..')),
           path: 'units/hero'
         },
         'L.T.R.': {
-          element: element(by.css('#sidebar-units-ltr')),
+          element: element(by.xpath('//a[text()[contains(., "L.T.R.")]]/..')),
           path: 'units/ltr'
         },
         'Demand & Projections': {
-          element: element(by.css('#sidebar-units-demand')),
+          element: element(by.xpath('//a[text()[contains(., "Demand & Projections")]]/..')),
           path: 'units/demand'
         }
       }
     },
     'Edit Demand & Projections': {
-      element: element(by.css('#sidebar-edit-demand')),
+      element: element(by.cssContainingText('li', 'Edit Demand & Projections')),
       path: 'edit-demand/edit'
     },
     'Intake/Vacancy Control': {
-      element: element(by.css('#sidebar-intake')),
+      element: element(by.cssContainingText('li', 'Intake/Vacancy Control')),
       path: 'ivc'
     },
     'Reports': {
-      element: element(by.css('#sidebar-reports')),
+      element: element(by.xpath('//span[text()[contains(., "Reports")]]/../..')),
       children: {
         'General Reports': {
-          element: element(by.css('#sidebar-reports-general')),
+          element: element(by.xpath('//a[text()[contains(., "General Reports")]]/..')),
           path: 'reports/general'
         },
         'Other Reports': {
-          element: element(by.css('#sidebar-reports-other')),
+          element: element(by.xpath('//a[text()[contains(., "Other Reports")]]/..')),
           children: {
             'Report All': {
-              element: element(by.css('#sidebar-reports-other-all')),
+              element: element(by.xpath('//a[text()[contains(., "Report All")]]/..')),
               path: 'reports/all'
             }
           }
@@ -62,19 +62,19 @@ export class SidebarPage {
       }
     },
     'App Settings': {
-      element: element(by.css('#sidebar-settings')),
+      element: element(by.cssContainingText('li.has-sub', 'App Settings')),
       children: {
         'General Settings': {
-          element: element(by.css('#sidebar-settings-general')),
+          element: element(by.xpath('//a[text()[contains(., "General Settings")]]/..')),
           path: 'settings/general'
         }
       }
     },
     'App Help': {
-      element: element(by.css('#sidebar-help')),
+      element: element(by.cssContainingText('li.has-sub', 'App Help')),
       children: {
         'General Help': {
-          element: element(by.css('#sidebar-help-general')),
+          element: element(by.xpath('//a[text()[contains(., "General Help")]]/..')),
           path: 'help/general'
         }
       }

--- a/e2e/page-objects/sidebar.po.ts
+++ b/e2e/page-objects/sidebar.po.ts
@@ -1,4 +1,7 @@
 import { browser, element, by } from 'protractor';
+import { E2EHelpers } from '../support/e2eHelpers';
+
+const helpers = new E2EHelpers();
 
 export class SidebarPage {
   items = {
@@ -82,33 +85,10 @@ export class SidebarPage {
   minifyBtn = element(by.css('.sidebar-minify-btn'));
 
   getItem(item) {
-    const items = this.items;
-
-    return item in items ? items[item] : this.findItem(item, items);
-  }
-
-  findItem(item, itemsObj) {
-    for (const menuItem in itemsObj) {
-      if (itemsObj[menuItem].subItems) {
-        if (itemsObj[menuItem].subItems[item]) {
-          return itemsObj[menuItem].subItems[item];
-        } else {
-          const found = this.findItem(item, itemsObj[menuItem].subItems);
-          if (found) {
-            return found;
-          }
-        }
-      }
-    }
+    return helpers.getItem(item, this.items);
   }
 
   getSubItem(subItem, item) {
-    const items = this.items;
-
-    if (item in items) {
-      return items[item].subItems[subItem];
-    } else {
-      return this.getItem(item).subItems[subItem];
-    }
+    return helpers.getSubItem(subItem, item, this.items);
   }
 }

--- a/e2e/support/e2eHelpers.ts
+++ b/e2e/support/e2eHelpers.ts
@@ -1,29 +1,17 @@
 import { browser, element, by } from 'protractor';
 
-import { LoginPage } from '../page-objects/login.po';
-import { HeaderPage } from '../page-objects/header.po';
-
-const loginPage: LoginPage = new LoginPage();
-const headerPage: HeaderPage = new HeaderPage();
-
 export class E2EHelpers {
 
-  getItem(item, items) {
-    return item in items ? items[item] : this.findItem(item, items);
-  }
-
-  findItem(itemToFind, items) {
-    for (const menuItem in items) {
-      if (items.hasOwnProperty(menuItem)) {
-        const subItems = items[menuItem];
-        for (const subItem in subItems) {
-          if (subItems[itemToFind]) {
-            return subItems[itemToFind];
-          } else {
-            if (subItems[subItem].element && !subItems[subItem].path) {
-              if (subItems[subItem][itemToFind]) {
-                return subItems[subItem][itemToFind];
-              }
+  getItem(item, obj) {
+    if (item in obj) {
+      return obj[item];
+    } else {
+      for (const prop in obj) {
+        if (obj.hasOwnProperty(prop)) {
+          if (obj[prop].children) {
+            const found = this.getItem(item, obj[prop].children);
+            if (found) {
+              return found;
             }
           }
         }
@@ -31,22 +19,15 @@ export class E2EHelpers {
     }
   }
 
-  confirmLogin () {
-    return browser.getCurrentUrl().then(url => {
-      if (/login/.test(url)) {
-        loginPage.login('sample_user@hra.nyc.gov', 'password');
+  getChild(item, obj) {
+    const children = this.getItem(item, obj).children;
+    for (const prop in children) {
+      if (children.hasOwnProperty(prop)) {
+        if (children[prop].element) {
+          return children[prop];
+        }
       }
-    });
-  }
-
-  logout() {
-    return browser.getCurrentUrl().then( url => {
-      if (!/login/.test(url)) {
-        return headerPage.getItem('User').click().then(() => {
-          return headerPage.getItem('Logout').click();
-        });
-      }
-    });
+    }
   }
 
   hasClass (classList, cssClass) {

--- a/e2e/support/e2eHelpers.ts
+++ b/e2e/support/e2eHelpers.ts
@@ -7,6 +7,34 @@ const loginPage: LoginPage = new LoginPage();
 const headerPage: HeaderPage = new HeaderPage();
 
 export class E2EHelpers {
+
+  getItem(item, items) {
+    return item in items ? items[item] : this.findItem(item, items);
+  }
+
+  getSubItem(subItem, item, items) {
+    if (item in items) {
+      return items[item].subItems[subItem];
+    } else {
+      return this.getItem(item, items).subItems[subItem];
+    }
+  }
+
+  findItem(item, itemsObj) {
+    for (const menuItem in itemsObj) {
+      if (itemsObj[menuItem].subItems) {
+        if (itemsObj[menuItem].subItems[item]) {
+          return itemsObj[menuItem].subItems[item];
+        } else {
+          const found = this.findItem(item, itemsObj[menuItem].subItems);
+          if (found) {
+            return found;
+          }
+        }
+      }
+    }
+  }
+
   confirmLogin () {
     return browser.getCurrentUrl().then(url => {
       if (/login/.test(url)) {

--- a/e2e/support/e2eHelpers.ts
+++ b/e2e/support/e2eHelpers.ts
@@ -12,15 +12,19 @@ export class E2EHelpers {
     return item in items ? items[item] : this.findItem(item, items);
   }
 
-  findItem(item, items) {
+  findItem(itemToFind, items) {
     for (const menuItem in items) {
-      if (items[menuItem].subItems) {
-        if (items[menuItem].subItems[item]) {
-          return items[menuItem].subItems[item];
-        } else {
-          const found = this.findItem(item, items[menuItem].subItems);
-          if (found) {
-            return found;
+      if (items.hasOwnProperty(menuItem)) {
+        const subItems = items[menuItem];
+        for (const subItem in subItems) {
+          if (subItems[itemToFind]) {
+            return subItems[itemToFind];
+          } else {
+            if (subItems[subItem].element && !subItems[subItem].path) {
+              if (subItems[subItem][itemToFind]) {
+                return subItems[subItem][itemToFind];
+              }
+            }
           }
         }
       }

--- a/e2e/support/e2eHelpers.ts
+++ b/e2e/support/e2eHelpers.ts
@@ -42,8 +42,8 @@ export class E2EHelpers {
   logout() {
     return browser.getCurrentUrl().then( url => {
       if (!/login/.test(url)) {
-        return headerPage.getElement('user', 'parent').click().then(() => {
-          return headerPage.getElement('user', 'child').click();
+        return headerPage.getItem('User').click().then(() => {
+          return headerPage.getItem('Logout').click();
         });
       }
     });

--- a/e2e/support/e2eHelpers.ts
+++ b/e2e/support/e2eHelpers.ts
@@ -1,14 +1,26 @@
 import { browser, element, by } from 'protractor';
 
 import { LoginPage } from '../page-objects/login.po';
+import { HeaderPage } from '../page-objects/header.po';
 
 const loginPage: LoginPage = new LoginPage();
+const headerPage: HeaderPage = new HeaderPage();
 
 export class E2EHelpers {
   confirmLogin () {
     return browser.getCurrentUrl().then(url => {
       if (/login/.test(url)) {
         loginPage.login('sample_user@hra.nyc.gov', 'password');
+      }
+    });
+  }
+
+  logout() {
+    return browser.getCurrentUrl().then( url => {
+      if (!/login/.test(url)) {
+        return headerPage.getElement('user', 'parent').click().then(() => {
+          return headerPage.getElement('user', 'child').click();
+        });
       }
     });
   }

--- a/e2e/support/e2eHelpers.ts
+++ b/e2e/support/e2eHelpers.ts
@@ -12,21 +12,13 @@ export class E2EHelpers {
     return item in items ? items[item] : this.findItem(item, items);
   }
 
-  getSubItem(subItem, item, items) {
-    if (item in items) {
-      return items[item].subItems[subItem];
-    } else {
-      return this.getItem(item, items).subItems[subItem];
-    }
-  }
-
-  findItem(item, itemsObj) {
-    for (const menuItem in itemsObj) {
-      if (itemsObj[menuItem].subItems) {
-        if (itemsObj[menuItem].subItems[item]) {
-          return itemsObj[menuItem].subItems[item];
+  findItem(item, items) {
+    for (const menuItem in items) {
+      if (items[menuItem].subItems) {
+        if (items[menuItem].subItems[item]) {
+          return items[menuItem].subItems[item];
         } else {
-          const found = this.findItem(item, itemsObj[menuItem].subItems);
+          const found = this.findItem(item, items[menuItem].subItems);
           if (found) {
             return found;
           }

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -24,7 +24,7 @@
           <span>Dashboard</span>
         </a>
         <ul class="sub-menu">
-          <li routerLinkActive="active" id="sidebar-sub-dashboard">
+          <li routerLinkActive="active">
             <a [routerLink]="['dashboard']">Dashboard</a>
           </li>
         </ul>
@@ -32,7 +32,6 @@
 
       <!-- ================== 02.0 Units ============================================================= -->
       <li class="has-sub"
-          id="sidebar-units"
           routerLinkActive="active"
           (click)="expandedMenu = 'units'"
           [ngClass]="{'expand': expandedMenu === 'units' }">
@@ -43,23 +42,23 @@
           <span>Units</span>
         </a>
         <ul class="sub-menu">
-          <li routerLinkActive="active" id="sidebar-units-offline">
+          <li routerLinkActive="active">
             <a [routerLink]="['units/offline-units']"><span class="badge pull-left">817</span>&nbsp;Offline Units</a>
           </li>
-          <li routerLinkActive="active" id="sidebar-units-hero">
+          <li routerLinkActive="active">
             <a [routerLink]="['units/hero']"><span class="badge pull-left">200</span>&nbsp;HERO</a>
           </li>
-          <li routerLinkActive="active" id="sidebar-units-ltr">
+          <li routerLinkActive="active">
             <a [routerLink]="['units/ltr']"><span class="badge pull-left">105</span>&nbsp;L.T.R.</a>
           </li>
-          <li routerLinkActive="active" id="sidebar-units-demand">
+          <li routerLinkActive="active">
             <a [routerLink]="['units/demand']"><span class="badge pull-left">38</span>&nbsp;Demand & Projections</a>
           </li>
         </ul>
       </li>
 
       <!-- ================== 03.0 Edit Demand & Projections ============================================================= -->
-      <li routerLinkActive="active" id="sidebar-edit-demand">
+      <li routerLinkActive="active">
         <a [routerLink]="['edit-demand/edit']"><i class="fa fa-edit"></i> <span>Edit Demand & Projections</span></a>
       </li>
 
@@ -70,7 +69,6 @@
 
       <!-- ================== 05.0 Reports ============================================================= -->
       <li class="has-sub"
-          id="sidebar-reports"
           routerLinkActive="active"
           (click)="expandedMenu = 'reports'"
           [ngClass]="{'expand': expandedMenu.startsWith('reports') }">
@@ -80,17 +78,16 @@
           <span>Reports </span>
         </a>
         <ul class="sub-menu">
-          <li routerLinkActive="active" id="sidebar-reports-general">
+          <li routerLinkActive="active">
             <a [routerLink]="['/reports/general']">General Reports</a>
           </li>
             <li class="has-sub"
-                id="sidebar-reports-other"
                 routerLinkActive="active"
                 (click)="$event.stopPropagation(); expandedMenu = 'reports/other'"
                 [ngClass]="{'expand': expandedMenu === ('reports/other') }">
             <a href="javascript:"><b class="caret pull-right"></b> Other Reports</a>
             <ul class="sub-menu">
-              <li routerLinkActive="active" id="sidebar-reports-other-all">
+              <li routerLinkActive="active">
                 <a [routerLink]="['/reports/all']">Report All</a>
               </li>
               <li routerLinkActive="active">
@@ -109,7 +106,6 @@
 
       <!-- ================== 09.0 App Settings ============================================================= -->
       <li class="has-sub"
-          id="sidebar-settings"
           routerLinkActive="active"
           (click)="expandedMenu = 'settings'"
           [ngClass]="{'expand': expandedMenu === 'settings' }">
@@ -119,7 +115,7 @@
           <span>App Settings</span>
         </a>
         <ul class="sub-menu">
-          <li routerLinkActive="active" id="sidebar-settings-general">
+          <li routerLinkActive="active">
             <a [routerLink]="['/settings/general']">General Settings</a>
           </li>
         </ul>
@@ -127,7 +123,6 @@
 
       <!-- ================== 10.0 App Help ============================================================= -->
       <li class="has-sub"
-          id="sidebar-help"
           routerLinkActive="active"
           (click)="expandedMenu = 'help'"
           [ngClass]="{'expand': expandedMenu === 'help' }">
@@ -137,7 +132,7 @@
           <span>App Help</span>
         </a>
         <ul class="sub-menu">
-          <li routerLinkActive="active" id="sidebar-help-general">
+          <li routerLinkActive="active">
             <a [routerLink]="['/help/general']">General Help</a>
           </li>
         </ul>

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -15,7 +15,6 @@
       </li>
       <!-- ================== 01.0 Dashboard ============================================================= -->
       <li class="has-sub"
-          id="sidebar-dashboard"
           routerLinkActive="active"
           (click)="expandedMenu = 'dashboard'"
           [ngClass]="{'expand': expandedMenu === 'dashboard' }">

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -85,12 +85,13 @@
             <a [routerLink]="['/reports/general']">General Reports</a>
           </li>
             <li class="has-sub"
+                id="sidebar-reports-other"
                 routerLinkActive="active"
                 (click)="$event.stopPropagation(); expandedMenu = 'reports/other'"
                 [ngClass]="{'expand': expandedMenu === ('reports/other') }">
             <a href="javascript:"><b class="caret pull-right"></b> Other Reports</a>
             <ul class="sub-menu">
-              <li routerLinkActive="active">
+              <li routerLinkActive="active" id="sidebar-reports-other-all">
                 <a [routerLink]="['/reports/all']">Report All</a>
               </li>
               <li routerLinkActive="active">


### PR DESCRIPTION
Primary goal was to add a few more tests for sidebar Reports All link and header user menu links.  In the process, decided to restructure sidebar page object and made header page object consistent with that structure.  Created `getItem()` method in e2e helpers which can be used on any page object that follows this structure.

Interested in all feedback of course, but a few specific points:
* Structure of `items` objects in sidebar and header page objects
* `getItem` method in `E2EHelpers`
* Added some `id` attributes to sidebar items for easy Protractor locating.  Is that okay, or should I find a way without using `id`?  

-- CAF:  As a general rule I try to avoid IDs for anything but top level container object, but if the selector is too complicated and the chances of duplicate IDs is zero, then ID is OK.
